### PR TITLE
レイアウトを調整し、ヘッダーに必要な情報のみ残すように修正 

### DIFF
--- a/rojineko_view/layouts/default.vue
+++ b/rojineko_view/layouts/default.vue
@@ -1,15 +1,6 @@
 <template>
   <v-app dark>
     <v-app-bar :clipped-left="clipped" fixed app>
-      <v-btn icon @click.stop="miniVariant = !miniVariant">
-        <v-icon>mdi-{{ `chevron-${miniVariant ? 'right' : 'left'}` }}</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="clipped = !clipped">
-        <v-icon>mdi-application</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="fixed = !fixed">
-        <v-icon>mdi-minus</v-icon>
-      </v-btn>
       <v-toolbar-title v-text="title" />
       <v-spacer />
     </v-app-bar>
@@ -30,9 +21,6 @@ export default {
   name: 'DefaultLayout',
   data() {
     return {
-      clipped: false,
-      fixed: false,
-      miniVariant: false,
       title: 'Vuetify.js',
     }
   },

--- a/rojineko_view/layouts/default.vue
+++ b/rojineko_view/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-app dark>
-    <v-app-bar :clipped-left="clipped" fixed app>
-      <v-toolbar-title v-text="title" />
+  <v-app>
+    <v-app-bar fixed app flat color="blue">
+      <v-toolbar-title :class="$style.toolbar_title" v-text="title" />
       <v-spacer />
     </v-app-bar>
     <v-main>
@@ -26,3 +26,10 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" module>
+.toolbar_title {
+  color: #ffffff;
+  font-weight: bold;
+}
+</style>

--- a/rojineko_view/layouts/default.vue
+++ b/rojineko_view/layouts/default.vue
@@ -21,7 +21,7 @@ export default {
   name: 'DefaultLayout',
   data() {
     return {
-      title: 'Vuetify.js',
+      title: 'ロジねこビュー',
     }
   },
 }

--- a/rojineko_view/layouts/default.vue
+++ b/rojineko_view/layouts/default.vue
@@ -1,31 +1,6 @@
 <template>
   <v-app dark>
-    <v-navigation-drawer
-      v-model="drawer"
-      :mini-variant="miniVariant"
-      :clipped="clipped"
-      fixed
-      app
-    >
-      <v-list>
-        <v-list-item
-          v-for="(item, i) in items"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
-          <v-list-item-action>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title v-text="item.title" />
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
     <v-app-bar :clipped-left="clipped" fixed app>
-      <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
       <v-btn icon @click.stop="miniVariant = !miniVariant">
         <v-icon>mdi-{{ `chevron-${miniVariant ? 'right' : 'left'}` }}</v-icon>
       </v-btn>
@@ -37,25 +12,13 @@
       </v-btn>
       <v-toolbar-title v-text="title" />
       <v-spacer />
-      <v-btn icon @click.stop="rightDrawer = !rightDrawer">
-        <v-icon>mdi-menu</v-icon>
-      </v-btn>
     </v-app-bar>
     <v-main>
       <v-container>
         <Nuxt />
       </v-container>
     </v-main>
-    <v-navigation-drawer v-model="rightDrawer" :right="right" temporary fixed>
-      <v-list>
-        <v-list-item @click.native="right = !right">
-          <v-list-item-action>
-            <v-icon light> mdi-repeat </v-icon>
-          </v-list-item-action>
-          <v-list-item-title>Switch drawer (click me)</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
+
     <v-footer :absolute="!fixed" app>
       <span>&copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
@@ -68,23 +31,8 @@ export default {
   data() {
     return {
       clipped: false,
-      drawer: false,
       fixed: false,
-      items: [
-        {
-          icon: 'mdi-apps',
-          title: 'Welcome',
-          to: '/',
-        },
-        {
-          icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire',
-        },
-      ],
       miniVariant: false,
-      right: true,
-      rightDrawer: false,
       title: 'Vuetify.js',
     }
   },


### PR DESCRIPTION
layouts/default.vue から不要な記述を削除
ヘッダーのデザインを [Vuetify のドキュメント](https://vuetifyjs.com/ja/components/app-bars/) を見ながら調整
ヘッダーのタイトルにアプリ名を表示